### PR TITLE
Proposed set of changes to allow the full toolchain to be build on an…

### DIFF
--- a/check_cz.sh
+++ b/check_cz.sh
@@ -5,7 +5,9 @@
 #  prompt install early on, rather than pausing for error hours later.
 #"***************************************************************************************************"
 echo "Checking for wget install..."
-sudo apt-get install wget --assume-yes
+if [ "$APTGET" == 1 ]; then
+  sudo apt-get install wget --assume-yes
+fi
 
 THIS_CZ=$(wget --no-hsts --quiet --output-document=- https://repo.or.cz/jimtcl.git/ |  grep -m 1 .)
 if [ "$?" != "0" ] || [ "$THIS_CZ" == "" ] ; then

--- a/fetch_github.sh
+++ b/fetch_github.sh
@@ -10,9 +10,6 @@
 # we don't want tee to capture exit codes
 set -o pipefail
 
-# ensure we alwaye start from the $WORKSPACE directory
-cd "$WORKSPACE"
-
 echo ""
 echo "fetch_github.sh working directory: $(pwd) with parameters:"
 echo ""

--- a/gitcheck.sh
+++ b/gitcheck.sh
@@ -39,7 +39,7 @@ CheckForGitFileChange() {
 	else 
 		echo "Warning! This version of $1 does not match the most recent version in GitHub!"
 		git status | tr -s ' ' | grep "modified: $1"
-		read -p "Press enter to continue, or Ctrl-C to abort. (manually push/pull recent file)"
+		# read -p "Press enter to continue, or Ctrl-C to abort. (manually push/pull recent file)"
 	fi
 	cd $SAVED_CURRENT_PATH
 }

--- a/init.sh
+++ b/init.sh
@@ -10,7 +10,7 @@ export SAVED_CURRENT_PATH=$(pwd)
 if [ "$ULX3S_COM" == "" ]; then
   export ULX3S_COM=/dev/ttyS15  # put your device name here, or set in ~/.bashrc
   echo ""
-  echo "Warning: setting ULX3S_COM to $ULX3S_COM - consider setting in your .bashrc file."
+  echo "Warning: setting ULX3S_COM to $ULX3S_COM - consider setting ULX3S_COM in your .bashrc file."
   echo ""
   read -p "Press enter to continue, or Ctrl-C to abort."
 else
@@ -29,8 +29,9 @@ if [ "$WORKSPACE" == "" ]; then
   fi
 fi
 
-# ensure the directory exists
-mkdir -p $WORKSPACE
+# ensure the workspace directory exists
+mkdir -p "$WORKSPACE"
+mkdir -p "$WORKSPACE/install_logs"
 
 # we will keep track of every install with suffixes YYYYMMSS_HHMMSS such as 20200307_105326
 export LOG_SUFFIX=$(date +"%Y%m%d_%H%M%S")
@@ -54,9 +55,6 @@ fi
 # typicaly log file name looks like /mnt/c/workspace/install_logs/install_ujprog_20200307_105326.log
 export THIS_LOG=$LOG_DIRECTORY"/"$THIS_FILE_NAME""$THIS_DELIM""$THIS_PARAM_NAME""_""$LOG_SUFFIX".log"
 
-mkdir -p "$WORKSPACE"
-mkdir -p "$WORKSPACE/install_logs"
-
 #"***************************************************************************************************"
 # check that we are not running as root
 #"***************************************************************************************************"
@@ -70,6 +68,5 @@ else
   echo "Startup install with root permissions! (not a good idea) Security Context: $(whoami)" 2>&1 | tee -a  "$THIS_LOG"
 fi
 
-cd "$WORKSPACE"
 echo ""
-echo "Installing to $(pwd)"
+echo "Installing to $WORKSPACE"

--- a/install.sh
+++ b/install.sh
@@ -1,13 +1,34 @@
 #!/bin/bash
-echo "sudo apt-get update..."
-# a fresh VM will sometimes not be able to install anything until after a fresh apt-get update
-sudo apt-get update
+export APTGET=0
+export BAREBONES=0
+
+for arg in "$@"
+do
+  if [ $arg == "barebones" ]; then
+    export BAREBONES=1
+  fi
+  if [ $arg == "aptget" ]; then
+    echo
+    echo "  'sudo apt-get install' will be used to install needed packages."
+    echo "  This only works on Ubuntu like Linux distro's!"
+    echo
+    export APTGET=1
+  fi
+done
+
+if [ "$APTGET" != 0 ]; then
+  # a fresh VM will sometimes not be able to install anything until after a fresh apt-get update
+  echo "sudo apt-get update..."
+  sudo apt-get update
+fi
 
 git --version
 retVal=$?
 if [ $retVal -ne 0 ]; then
+  if [ "$APTGET" != 0 ]; then
     echo "installing git..."
     sudo apt-get install git --assume-yes
+  fi
 fi
 
 # active toolchain component developers may wish to set this to something other than the default.
@@ -15,22 +36,22 @@ fi
 if [ "$WORKSPACE" == "" ]; then
   if grep -q Microsoft /proc/version; then
     # Set default WSL location to C:\workspace
-    mkdir -p /mnt/c/workspace
-    export WORKSPACE=/mnt/c/workspace # put your WSL linux path here. Placed outside of WSL file system for easy refresh
+    export WORKSPACE=/mnt/c/ULX3S_workspace # put your WSL linux path here. Placed outside of WSL file system for easy refresh
   else
     # Set Ubuntu location to home directory ~/workspace
-    mkdir -p ~/workspace
-    export WORKSPACE=~/workspace  # put your pure linux workspace parent directory here.
+    export WORKSPACE=~/ULX3S_workspace  # put your pure linux workspace parent directory here.
   fi
 else
   echo "Using WORKSPACE=$WORKSPACE"
-  mkdir -p $WORKSPACE
 fi
+mkdir -p $WORKSPACE
 
+pushd .
 cd "$WORKSPACE"
-pwd
 
-
+# Why would we need a copy of the toolchain repo in our workspace which can be 
+# different than the one we build this workspace from? It's very confusing when 
+# debugging the install scripts.
 if [ ! -d "$WORKSPACE"/ulx3s-toolchain ]; then
   echo "clone ulx3s-toolchain..."
   git clone https://github.com/ulx3s/ulx3s-toolchain.git
@@ -42,6 +63,11 @@ else
   git pull
 fi
 
+popd
+
+# Why would we need a copy of the toolchain repo in our workspace which can be 
+# different than the one we build this workspace from? It's very confusing when 
+# debugging the install scripts.
 if [ ! -d "$WORKSPACE"/ulx3s-toolchain ]; then
   echo ""
   echo "Error cloning with git. Check permissions of $WORKSPACE"
@@ -58,18 +84,16 @@ else
   chmod +x install_set_permissions.sh
   chmod +x dos2unix.sh
 
-  ./install_set_permissions.sh
+  ./install_set_permissions.sh > /dev/null 2>&1
 
-  if [ "$1" == "barebones" ]; then
+  if [ "$BAREBONES" == 1 ]; then
     echo "Running ./install_barebones.sh"
-    chmod +x ./install_barebones.sh
+    chmod +x ./install_barebones.sh > /dev/null 2>&1
     ./install_barebones.sh
-
   else 
     echo "Running ./install_all.sh"
-    chmod +x ./install_all.sh
+    chmod +x ./install_all.sh > /dev/null 2>&1
     ./install_all.sh
-
-    echo "Done!"
   fi
+  echo "Done!"
 fi

--- a/install_all.sh
+++ b/install_all.sh
@@ -3,9 +3,8 @@
 #  ensure all the scripts here are executable
 #"***************************************************************************************************"
 echo "setting permissions"
-pwd
 chmod +x install_set_permissions.sh
-./install_set_permissions.sh
+./install_set_permissions.sh  > /dev/null 2>&1
 
 #"***************************************************************************************************"
 #  common initialization
@@ -19,7 +18,6 @@ chmod +x install_set_permissions.sh
 # we don't want tee to capture exit codes
 set -o pipefail
 
-cd "$WORKSPACE"
 #"***************************************************************************************************"
 #  check for minimum system resources needed (typically 40GB new Ubuntu VM with 5GB RAM)
 #"***************************************************************************************************"
@@ -38,8 +36,6 @@ if [ $(df $PWD | awk '/[0-9]%/{print $(NF-2)}' ) -lt "$MIN_ULX3S_DISK" ]; then
   echo ""
   read -p "Warning: At least $MIN_ULX3S_DISK bytes of free disk space is needed. Press a key to continue"
 fi
-
-cd $SAVED_CURRENT_PATH
 
 # check to see if we can reach repo.or.cz now, rather than pause with error later
 ./check_cz.sh
@@ -98,7 +94,7 @@ read -p "Press enter to continue and install everything, or Ctrl-C to abort."
 
 # more examples and tools
 ./install_rxrbln-picorv32.sh
-./install_ujprog.sh
+# ./install_ujprog.sh Deprecated? Won't install on Manjaro Linux (wrong hardcoded paths to libftdi and libusb).
 ./install_fujprog.sh
 ./install_blinky.sh
 ./install_fpga_odysseus.sh
@@ -110,10 +106,12 @@ read -p "Press enter to continue and install everything, or Ctrl-C to abort."
 # run a synthesis
 ./install_litex-ulx3s.sh
 
-echo "***************************************************************************************************"
-echo "update current system again. Saving log to $THIS_LOG"
-echo "***************************************************************************************************"
-sudo apt-get upgrade --assume-yes        2>&1 | tee -a "$THIS_LOG"
+if [ "$APTGET" == 1 ]; then
+  echo "***************************************************************************************************"
+  echo "update current system again. Saving log to $THIS_LOG"
+  echo "***************************************************************************************************"
+  sudo apt-get upgrade --assume-yes        2>&1 | tee -a "$THIS_LOG"
+fi
 
 if [ "$(sudo cat /etc/sudoers | grep timestamp_timeout)" != "" ]; then
   echo ""
@@ -126,6 +124,5 @@ fi
 echo ""
 echo "See logs in $LOG_DIRECTORY"
 echo ""
-
 
 echo "Completed $0 " | tee -a "$THIS_LOG"

--- a/install_arachne-pnr.sh
+++ b/install_arachne-pnr.sh
@@ -16,7 +16,6 @@ THIS_CLEAN=true
 # we don't want tee to capture exit codes
 set -o pipefail
 
-cd "$WORKSPACE"
 #"***************************************************************************************************"
 # arachne-pnr
 #"***************************************************************************************************"
@@ -24,13 +23,15 @@ echo "**************************************************************************
 echo " arachne-pnr. Saving log to $THIS_LOG"
 echo "***************************************************************************************************"
 
-
 # Call the common github checkout:
 
-$SAVED_CURRENT_PATH/fetch_github.sh https://github.com/cseed/arachne-pnr.git arachne-pnr $THIS_CHECKOUT  2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+pushd .
+cd "$WORKSPACE"
 
-cd arachne-pnr
+$SAVED_CURRENT_PATH/fetch_github.sh https://github.com/cseed/arachne-pnr.git arachne-pnr $THIS_CHECKOUT  2>&1 | tee -a "$THIS_LOG"
+$SAVED_CURRENT_PATH/check_for_error.sh                                                                     $?          "$THIS_LOG"
+
+cd "$WORKSPACE"/arachne-pnr
 
 # optional clean
 if [ "$THIS_CLEAN" == "true" ]; then  
@@ -40,12 +41,12 @@ if [ "$THIS_CLEAN" == "true" ]; then
   $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
 fi
 
-make                                                             2>&1 | tee -a "$THIS_LOG"
+make -j$(nproc)                                                   2>&1 | tee -a "$THIS_LOG"
 $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
 
-sudo make install                                                2>&1 | tee -a "$THIS_LOG"
+sudo make install                                                 2>&1 | tee -a "$THIS_LOG"
 $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
 
-cd $SAVED_CURRENT_PATH
-
-echo "Completed $0 "                                                  | tee -a "$THIS_LOG"
+popd
+echo "Completed $0 "                                                   | tee -a "$THIS_LOG"
+echo "----------------------------------"

--- a/install_barebones.sh
+++ b/install_barebones.sh
@@ -12,11 +12,9 @@
 # we don't want tee to capture exit codes
 set -o pipefail
 
-cd "$WORKSPACE"/ulx3s-toolchain
 echo "Barebone install!"
-pwd
 
-./install_set_permissions.sh
+./install_set_permissions.sh > /dev/null 2>&1
 
 # system updates and dependencies
 ./install_system.sh
@@ -25,6 +23,7 @@ pwd
 ./install_udev_rules.sh
 
 ./install_verilator.sh
+
 ./install_yosys.sh
 
 ./install_prjtrellis.sh
@@ -32,5 +31,3 @@ pwd
 ./install_nextpnr.sh ecp5
 
 ./install_fujprog.sh
-
-echo "Done!"

--- a/install_blinky.sh
+++ b/install_blinky.sh
@@ -16,8 +16,6 @@ THIS_CLEAN=true
 # we don't want tee to capture exit codes
 set -o pipefail
 
-# ensure we alwaye start from the $WORKSPACE directory
-cd "$WORKSPACE"
 #"***************************************************************************************************"
 # fetch @DoctorWkt FPGA ULX3S-Blinky into workspace
 #"***************************************************************************************************"
@@ -28,13 +26,37 @@ echo "**************************************************************************
 
 # Call the common github checkout:
 
+pushd .
+cd "$WORKSPACE"
+
 $SAVED_CURRENT_PATH/fetch_github.sh https://github.com/DoctorWkt/ULX3S-Blinky ULX3S-Blinky $THIS_CHECKOUT  2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+$SAVED_CURRENT_PATH/check_for_error.sh                                                                       $?          "$THIS_LOG"
 
-cd ULX3S-Blinky
+cd "$WORKSPACE"/ULX3S-Blinky
 
-# TODO make?
+# make  # --> will produce errors
+        # verilator -O3 -MMD --trace -Wall -cc blinky.v
+        # %Error: blinky.v:5:10: Duplicate declaration of signal: 'i_clk'
+        #                     : ... note: ANSI ports must have type declared with the I/O (IEEE 1800-2017 23.2.2.2)
+        #     5 |     wire i_clk;
+        #     |          ^~~~~
+        #         blinky.v:3:21: ... Location of original declaration
+        #     3 | module blinky(input i_clk, input [6:0] btn, output [7:0] o_led);
+        #     |                     ^~~~~
+        # %Error: blinky.v:6:16: Duplicate declaration of signal: 'btn'
+        #     6 |     wire [6:0] btn;
+        #     |                ^~~
+        #         blinky.v:3:40: ... Location of original declaration
+        #     3 | module blinky(input i_clk, input [6:0] btn, output [7:0] o_led);
+        #     |                                        ^~~
+        # %Error: blinky.v:7:16: Duplicate declaration of signal: 'o_led'
+        #     7 |     wire [7:0] o_led;
+        #     |                ^~~~~
+        #         blinky.v:3:58: ... Location of original declaration
+        #     3 | module blinky(input i_clk, input [6:0] btn, output [7:0] o_led);
+        #     |                                                          ^~~~~
+        # %Error: Exiting due to 3 error(s)
 
-cd $SAVED_CURRENT_PATH
-
+popd
 echo "Completed $0 "                                                  | tee -a "$THIS_LOG"
+echo "----------------------------------"

--- a/install_dfu-util.sh
+++ b/install_dfu-util.sh
@@ -16,8 +16,6 @@ THIS_CLEAN=true
 # we don't want tee to capture exit codes
 set -o pipefail
 
-# ensure we alwaye start from the $WORKSPACE directory
-cd "$WORKSPACE"
 #"***************************************************************************************************"
 # install the dfu-util form from ulx3s. 
 #
@@ -33,25 +31,30 @@ echo "**************************************************************************
 
 # Call the common github checkout:
 
-$SAVED_CURRENT_PATH/fetch_github.sh https://github.com/ulx3s/dfu-util.git dfu-util $THIS_CHECKOUT  2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+pushd .
+cd "$WORKSPACE"
 
-cd dfu-util
+$SAVED_CURRENT_PATH/fetch_github.sh https://github.com/ulx3s/dfu-util.git dfu-util $THIS_CHECKOUT  2>&1 | tee -a "$THIS_LOG"
+$SAVED_CURRENT_PATH/check_for_error.sh                                                               $?          "$THIS_LOG"
+
+cd "$WORKSPACE"/dfu-util
 
 # See INSTALL file for building
 
 # we'll install the apt-get version for now...
 dfu-util --version > /dev/null 2>&1
 if [ "$?" != "0" ]; then
-  echo "installing dfu-util ..."
-  sudo apt-get install dfu-util --assume-yes                        2>&1 | tee -a "$THIS_LOG"
+  if [ "$APTGET" == 1 ]; then
+    echo "installing dfu-util ..."
+    sudo apt-get install dfu-util --assume-yes                      2>&1 | tee -a "$THIS_LOG"
+  fi
 else
   echo "Skipping install of dfu-util. Already installed."           2>&1 | tee -a "$THIS_LOG"
 fi
 echo ""                                                             2>&1 | tee -a "$THIS_LOG"
 
 dfu-util --version                                                  2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+$SAVED_CURRENT_PATH/check_for_error.sh                                $?          "$THIS_LOG"
 
 # Generate build system files (requires autoconf from autotools)
 # ./autogen.sh
@@ -65,7 +68,6 @@ $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
 # Install executables and manual pages (optional)
 # sudo make install
 
-
-cd $SAVED_CURRENT_PATH
-
-echo "Completed $0 "                                                  | tee -a "$THIS_LOG"
+popd
+echo "Completed $0 "                                                     | tee -a "$THIS_LOG"
+echo "----------------------------------"

--- a/install_esp32.sh
+++ b/install_esp32.sh
@@ -11,42 +11,43 @@
 # we don't want tee to capture exit codes
 set -o pipefail
 
-# ensure we alwaye start from the $WORKSPACE directory
-cd "$WORKSPACE"
 #"***************************************************************************************************"
 # 
 # see https://docs.espressif.com/projects/esp-idf/en/latest/get-started/index.html#get-started-get-esp-idf
 #"***************************************************************************************************"
 
-# the old idf needed these:
-sudo apt-get install libncurses-dev gawk gperf grep gettext python python-dev \
-     automake bison flex texinfo help2man libtool libtool-bin make unzip --assume-yes   2>&1 | tee -a "$THIS_LOG"
+if [ "$APTGET" == 1 ]; then
+  # the old idf needed these:
+  sudo apt-get install libncurses-dev gawk gperf grep gettext python python-dev \
+       automake bison flex texinfo help2man libtool libtool-bin make unzip --assume-yes   2>&1 | tee -a "$THIS_LOG"
 
 
-# the new idf needs theses:
-sudo apt-get install git wget flex bison gperf python python-pip python-setuptools \
-     make ninja-build ccache libffi-dev libssl-dev                 --assume-yes   2>&1 | tee -a "$THIS_LOG"
+  # the new idf needs theses:
+  sudo apt-get install git wget flex bison gperf python python-pip python-setuptools \
+       make ninja-build ccache libffi-dev libssl-dev                 --assume-yes   2>&1 | tee -a "$THIS_LOG"
 
-sudo apt-get install python3 python3-pip python3-setuptools        --assume-yes   2>&1 | tee -a "$THIS_LOG"
+  sudo apt-get install python3 python3-pip python3-setuptools        --assume-yes   2>&1 | tee -a "$THIS_LOG"
 
-# TODO - create this directory?
-#
-# Directory '/home/gojimmypi/src' does not exist.
-# [WARN ]  Will not save downloaded tarballs to local storage.
+  # TODO - create this directory?
+  #
+  # Directory '/home/gojimmypi/src' does not exist.
+  # [WARN ]  Will not save downloaded tarballs to local storage.
 
-# see https://github.com/ulx3s/ulx3s-toolchain/issues/5
-# see https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/linux-setup.html#setting-up-python-3-as-default-for-ubuntu-and-debian
-sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
+  # see https://github.com/ulx3s/ulx3s-toolchain/issues/5
+  # see https://docs.espressif.com/projects/esp-idf/en/latest/esp32/get-started/linux-setup.html#setting-up-python-3-as-default-for-ubuntu-and-debian
+  sudo update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 
-#if [ "$(lsb_release --release)" == "Release:        20.04" ]; then
-#  alias pip="pip3"
-#else
-#  sudo apt-get install python-pip                                    --assume-yes   2>&1 | tee -a "$THIS_LOG"
-#fi
+  #if [ "$(lsb_release --release)" == "Release:        20.04" ]; then
+  #  alias pip="pip3"
+  #else
+  #  sudo apt-get install python-pip                                    --assume-yes   2>&1 | tee -a "$THIS_LOG"
+  #fi
+fi
 
 #  ensure our idf home diredtory exists
-mkdir -p ~/esp
-cd ~/esp
+mkdir -p "$WORKSPACE"/esp
+pushd .
+cd "$WORKSPACE"/esp
 
 #"***************************************************************************************************"
 # ESP32 toolchain installed to ~/esp
@@ -56,16 +57,16 @@ echo "**************************************************************************
 echo " ESP32 crosstool-NG. Saving log to $THIS_LOG"
 echo " see https://docs.espressif.com/projects/esp-idf/en/latest/get-started/linux-setup-scratch.html#compile-the-toolchain-from-source"
 echo "***************************************************************************************************"
-if [ ! -d ~/esp/crosstool-NG ]; then
+if [ ! -d "$WORKSPACE"/esp/crosstool-NG ]; then
   # Download crosstool-NG and build it:
   git clone https://github.com/espressif/crosstool-NG.git
-  $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+  $SAVED_CURRENT_PATH/check_for_error.sh                                     $? "$THIS_LOG"
   cd crosstool-NG
 else
   cd crosstool-NG
   git fetch                                                       2>&1 | tee -a "$THIS_LOG"
   git pull                                                        2>&1 | tee -a "$THIS_LOG"
-  $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+  $SAVED_CURRENT_PATH/check_for_error.sh                                     $? "$THIS_LOG"
 fi
 
 echo ""                                                           2>&1 | tee -a "$THIS_LOG"
@@ -73,12 +74,12 @@ echo "checking out crosstool-NG esp-2019r2 (disabled!)"           2>&1 | tee -a 
 echo ""                                                           2>&1 | tee -a "$THIS_LOG"
 #git checkout esp-2019r2                                          2>&1 | tee -a "$THIS_LOG"
 git submodule update --init                                       2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+$SAVED_CURRENT_PATH/check_for_error.sh                              $?          "$THIS_LOG"
 
 echo ""                                                           2>&1 | tee -a "$THIS_LOG"
 echo "ESP32 bootstrap and configure... "                          2>&1 | tee -a "$THIS_LOG"
 echo ""                                                           2>&1 | tee -a "$THIS_LOG"
-./bootstrap && ./configure --enable-local && make                 2>&1 | tee -a "$THIS_LOG"
+./bootstrap && ./configure --enable-local && make -j$(nproc)      2>&1 | tee -a "$THIS_LOG"
 
 # Build the toolchain:
 echo Ready to build ESP32 toolchain... $(pwd)                     2>&1 | tee -a "$THIS_LOG"
@@ -91,32 +92,31 @@ $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
 
 chmod -R u+w builds/xtensa-esp32-elf
 
-cd $SAVED_CURRENT_PATH
-
 #"***************************************************************************************************"
 #
 #"***************************************************************************************************"
-cd ~/esp
+cd "$WORKSPACE"/esp
 
 echo "***************************************************************************************************"
 echo " ESP32 esp-idf. Saving log to $THIS_LOG"
 echo "***************************************************************************************************"
-if [ ! -d ~/esp/esp-idf ]; then
-  git clone --recursive https://github.com/espressif/esp-idf.git 2>&1 | tee -a "$THIS_LOG"
-  cd ~/esp/esp-idf
+if [ ! -d "$WORKSPACE"/esp/esp-idf ]; then
+  git clone --recursive https://github.com/espressif/esp-idf.git  2>&1 | tee -a "$THIS_LOG"
+  cd "$WORKSPACE"/esp/esp-idf
 else
-  cd ~/esp/esp-idf
+  cd "$WORKSPACE"/esp/esp-idf
   git fetch                                                       2>&1 | tee -a "$THIS_LOG"
   git pull                                                        2>&1 | tee -a "$THIS_LOG"
-  $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+  $SAVED_CURRENT_PATH/check_for_error.sh                            $?          "$THIS_LOG"
 fi
 
 ./install.sh                                             
-$SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
-
+$SAVED_CURRENT_PATH/check_for_error.sh                              $?          "$THIS_LOG"
 
 # needed in ~/.bashrc
-cd ~/esp/esp-idf/
-. ./export.sh                                                    2>&1 | tee -a "$THIS_LOG"
+cd "$WORKSPACE"/esp/esp-idf/
+. ./export.sh                                                     2>&1 | tee -a "$THIS_LOG"
 
-echo "Completed $0 "                                                  | tee -a "$THIS_LOG"
+popd
+echo "Completed $0 "                                                   | tee -a "$THIS_LOG"
+echo "----------------------------------"

--- a/install_fpga_odysseus.sh
+++ b/install_fpga_odysseus.sh
@@ -16,21 +16,18 @@ THIS_CLEAN=true
 # we don't want tee to capture exit codes
 set -o pipefail
 
-# ensure we alwaye start from the $WORKSPACE directory
-cd "$WORKSPACE"
 #"***************************************************************************************************"
 # fpga-odysseus example
 #"***************************************************************************************************"
 
 # Call the common github checkout:
 
+pushd .
+cd "$WORKSPACE"
+
 $SAVED_CURRENT_PATH/fetch_github.sh https://github.com/ulx3s/fpga-odysseus.git fpga-odysseus $THIS_CHECKOUT  2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+$SAVED_CURRENT_PATH/check_for_error.sh                                                                         $?          "$THIS_LOG"
 
-cd fpga-odysseus
-
-
-
-cd $SAVED_CURRENT_PATH
-
+popd
 echo "Completed $0 "                                                  | tee -a "$THIS_LOG"
+echo "----------------------------------"

--- a/install_fujprog.sh
+++ b/install_fujprog.sh
@@ -17,8 +17,6 @@ THIS_CLEAN=true
 # we don't want tee to capture exit codes
 set -o pipefail
 
-# ensure we alwaye start from the $WORKSPACE directory
-cd "$WORKSPACE"
 #"***************************************************************************************************"
 # Install fujprog from f32c (used to upload binaries to ULX3S)
 #"***************************************************************************************************"
@@ -26,12 +24,17 @@ echo "**************************************************************************
 echo " fujprog. Saving log to $THIS_LOG"
 echo "***************************************************************************************************"
 
-sudo apt-get install libftdi1-dev libusb-dev cmake make build-essential --assume-yes 2>&1 | tee -a "$THIS_LOG"
+if [ "$APTGET" == 1 ]; then
+  sudo apt-get install libftdi1-dev libusb-dev cmake make build-essential --assume-yes 2>&1 | tee -a "$THIS_LOG"
+fi
+
+pushd .
+cd "$WORKSPACE"
 
 $SAVED_CURRENT_PATH/fetch_github.sh https://github.com/kost/fujprog.git fujprog $THIS_CHECKOUT  2>&1 | tee -a "$THIS_LOG"
 $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
 
-cd fujprog
+cd "$WORKSPACE"/fujprog
 
 # There's no point to making the linux version of fujprog in WSL, as native USB devices are not supported.
 # but we can compile the Windows version, amd actually call it from WSL (call from /mnt/c... not ~/...)
@@ -52,12 +55,12 @@ else
   mkdir -p build
   cd build
   cmake ..                                                       2>&1 | tee -a "$THIS_LOG"
-  make                                                           2>&1 | tee -a "$THIS_LOG"
+  make -j$(nproc)                                                2>&1 | tee -a "$THIS_LOG"
 
   sudo make install                                              2>&1 | tee -a "$THIS_LOG"
   $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
 fi
 
-cd $SAVED_CURRENT_PATH
-
+popd
 echo "Completed $0"                                                   | tee -a "$THIS_LOG"
+echo "----------------------------------"

--- a/install_icestorm.sh
+++ b/install_icestorm.sh
@@ -16,8 +16,6 @@ THIS_CLEAN=true
 # we don't want tee to capture exit codes
 set -o pipefail
 
-# ensure we alwaye start from the $WORKSPACE directory
-cd "$WORKSPACE"
 #"***************************************************************************************************"
 # icestorm
 #"***************************************************************************************************"
@@ -29,10 +27,13 @@ echo "**************************************************************************
 
 # Call the common github checkout:
 
-$SAVED_CURRENT_PATH/fetch_github.sh https://github.com/cliffordwolf/icestorm.git icestorm $THIS_CHECKOUT  2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+pushd .
+cd "$WORKSPACE"
 
-cd icestorm
+$SAVED_CURRENT_PATH/fetch_github.sh https://github.com/cliffordwolf/icestorm.git icestorm $THIS_CHECKOUT  2>&1 | tee -a "$THIS_LOG"
+$SAVED_CURRENT_PATH/check_for_error.sh                                                                      $?          "$THIS_LOG"
+
+cd "$WORKSPACE"/icestorm
 
 # optional clean
 if [ "$THIS_CLEAN" == "true" ]; then  
@@ -42,12 +43,12 @@ if [ "$THIS_CLEAN" == "true" ]; then
   $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
 fi
 
-make -j$(nproc)                                                   2>&1 | tee -a "$THIS_LOG"
+make -j$(nproc)                                                    2>&1 | tee -a "$THIS_LOG"
 $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
 
-sudo make install                                                 2>&1 | tee -a "$THIS_LOG"
+sudo make install                                                  2>&1 | tee -a "$THIS_LOG"
 $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
 
-cd $SAVED_CURRENT_PATH
-
-echo "Completed $0 "                                                  | tee -a "$THIS_LOG"
+popd
+echo "Completed $0 "                                                    | tee -a "$THIS_LOG"
+echo "----------------------------------"

--- a/install_iverilog.sh
+++ b/install_iverilog.sh
@@ -16,8 +16,6 @@ THIS_CLEAN=true
 # we don't want tee to capture exit codes
 set -o pipefail
 
-# ensure we alwaye start from the $WORKSPACE directory
-cd "$WORKSPACE"
 #"***************************************************************************************************"
 # icestorm
 #"***************************************************************************************************"
@@ -25,14 +23,19 @@ echo "**************************************************************************
 echo " icestorm. Saving log to: "$THIS_LOG
 echo "***************************************************************************************************"
 
-sudo apt-get install autoconf gperf --assume-yes                  2>&1 | tee -a "$THIS_LOG"
+if [ "$APTGET" == 1 ]; then
+  sudo apt-get install autoconf gperf --assume-yes                  2>&1 | tee -a "$THIS_LOG"
+fi
 
 # Call the common github checkout:
+
+pushd .
+cd "$WORKSPACE"
 
 $SAVED_CURRENT_PATH/fetch_github.sh https://github.com/steveicarus/iverilog.git iverilog $THIS_CHECKOUT  2>&1 | tee -a "$THIS_LOG"
 $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
 
-cd iverilog
+cd "$WORKSPACE"/iverilog
 
 # optional clean
 #if [ "$THIS_CLEAN" == "true" ]; then  
@@ -44,13 +47,12 @@ cd iverilog
 
 sh autoconf.sh                                                    2>&1 | tee -a "$THIS_LOG"
 ./configure                                                       2>&1 | tee -a "$THIS_LOG"
-make                                                              2>&1 | tee -a "$THIS_LOG"
+make -j$(nproc)                                                   2>&1 | tee -a "$THIS_LOG"
 $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
-
 
 sudo make install                                                 2>&1 | tee -a "$THIS_LOG"
 $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
 
-cd $SAVED_CURRENT_PATH
-
+popd
 echo "Completed $0"                                                    | tee -a "$THIS_LOG"
+echo "----------------------------------"

--- a/install_litex.sh
+++ b/install_litex.sh
@@ -16,28 +16,31 @@ THIS_CLEAN=true
 # we don't want tee to capture exit codes
 set -o pipefail
 
-# ensure we alwaye start from the $WORKSPACE directory
-cd "$WORKSPACE"
 #"***************************************************************************************************"
 #  Install LiteX
 #
 #  see https://github.com/enjoy-digital/litex/ 
 #"***************************************************************************************************"
 
-# LiteX system requirements (also requires riscv32-unknown-elf-gcc)
-sudo apt-get install build-essential device-tree-compiler wget git python3-setuptools --assume-yes 2>&1 | tee -a "$THIS_LOG"
+if [ "$APTGET" == 1 ]; then
+  # LiteX system requirements (also requires riscv32-unknown-elf-gcc)
+  sudo apt-get install build-essential device-tree-compiler wget git python3-setuptools --assume-yes 2>&1 | tee -a "$THIS_LOG"
 
-# LiteX sim requirements
-sudo apt-get install libevent-dev libjson-c-dev verilator --assume-yes            2>&1 | tee -a "$THIS_LOG"
+  # LiteX sim requirements
+  sudo apt-get install libevent-dev libjson-c-dev verilator --assume-yes                             2>&1 | tee -a "$THIS_LOG"
+fi
 
 # ensure we have the RISC-V compiler isntalled
-/opt/riscv32i/bin/riscv32-unknown-elf-gcc --version                               2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+/opt/riscv32i/bin/riscv32-unknown-elf-gcc --version                                 2>&1 | tee -a "$THIS_LOG"
+$SAVED_CURRENT_PATH/check_for_error.sh                                                $?          "$THIS_LOG"
 
 if [ "$?" != "0" ]; then
   echo    "Error /opt/riscv32i/bin/riscv32-unknown-elf-gcc not found"
   read -p "Press enter to continue, or Ctrl-C to abort."
 fi
+
+pushd .
+cd "$WORKSPACE"
 
 # $ wget https://raw.githubusercontent.com/enjoy-digital/litex/master/litex_setup.py
 # $ chmod +x litex_setup.py
@@ -47,11 +50,11 @@ if [ ! -f "$WORKSPACE"/litex_setup.py ]; then
   wget https://raw.githubusercontent.com/enjoy-digital/litex/master/litex_setup.py  2>&1 | tee -a "$THIS_LOG"
   chmod +x litex_setup.py                                                           2>&1 | tee -a "$THIS_LOG"
 
-  ./litex_setup.py init --user                                                       2>&1 | tee -a "$THIS_LOG"
-  $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+  ./litex_setup.py init --user                                                      2>&1 | tee -a "$THIS_LOG"
+  $SAVED_CURRENT_PATH/check_for_error.sh                                              $?          "$THIS_LOG"
 
-  ./litex_setup.py install --user                                                    2>&1 | tee -a "$THIS_LOG"
-  $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+  ./litex_setup.py install --user                                                   2>&1 | tee -a "$THIS_LOG"
+  $SAVED_CURRENT_PATH/check_for_error.sh                                              $?          "$THIS_LOG"
 else
   mv litex_setup.py litex_setup.py.old
 
@@ -75,8 +78,7 @@ fi
 # TODO 
 # ./litex_setup.py update
 
-cd "$WORKSPACE"
-THIS_LOG=$LOG_DIRECTORY"/"$THIS_FILE_NAME"_linux-on-litex-vexriscv_"$LOG_SUFFIX".log"
+cd "$WORKSPACE"THIS_LOG=$LOG_DIRECTORY"/"$THIS_FILE_NAME"_linux-on-litex-vexriscv_"$LOG_SUFFIX".log"
 
 echo "***************************************************************************************************"
 echo " linux-on-litex-vexriscv. Saving log to $THIS_LOG"
@@ -85,13 +87,14 @@ echo "**************************************************************************
 # Call the common github checkout:
 
 $SAVED_CURRENT_PATH/fetch_github.sh https://github.com/enjoy-digital/linux-on-litex-vexriscv linux-on-litex-vexriscv $THIS_CHECKOUT  2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+$SAVED_CURRENT_PATH/check_for_error.sh                                                                                                 $?          "$THIS_LOG"
 
-cd linux-on-litex-vexriscv
+cd "$WORKSPACE"/linux-on-litex-vexriscv
 
 sudo chown $USER $WORKSPACE/litex/litex/boards/targets/
 sudo chown $USER $WORKSPACE/litex-boards/litex_boards/targets
 
+popd
 . $SAVED_CURRENT_PATH/set_riscv_path.sh
-
 echo "Completed $0 "                                                   | tee -a "$THIS_LOG"
+echo "----------------------------------"

--- a/install_openocd-esp32.sh
+++ b/install_openocd-esp32.sh
@@ -37,8 +37,6 @@ THIS_CLEAN=true
 # we don't want tee to capture exit codes
 set -o pipefail
 
-# ensure we alwaye start from the $WORKSPACE directory
-cd "$WORKSPACE"
 #"***************************************************************************************************"
 # Install OpenOCD for the ESP32
 #"***************************************************************************************************"
@@ -49,10 +47,13 @@ echo "**************************************************************************
 
 # Call the common github checkout:
 
-$SAVED_CURRENT_PATH/fetch_github.sh https://github.com/espressif/openocd-esp32 openocd-esp32 $THIS_CHECKOUT  2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+pushd .
+cd "$WORKSPACE"
 
-cd openocd-esp32
+$SAVED_CURRENT_PATH/fetch_github.sh https://github.com/espressif/openocd-esp32 openocd-esp32 $THIS_CHECKOUT  2>&1 | tee -a "$THIS_LOG"
+$SAVED_CURRENT_PATH/check_for_error.sh                                                                         $?          "$THIS_LOG"
+
+cd "$WORKSPACE"/openocd-esp32
 
 # TODO is this installed to same location as regular openocd?
 
@@ -66,10 +67,12 @@ echo ""                            | tee -a "$THIS_LOG"
 
 echo ""                            | tee -a "$THIS_LOG"
 echo "make"                        | tee -a "$THIS_LOG"
-make                          2>&1 | tee -a "$THIS_LOG"
+make -j$(nproc)               2>&1 | tee -a "$THIS_LOG"
 
 echo ""                            | tee -a "$THIS_LOG"
 echo "sudo make install"           | tee -a "$THIS_LOG"
 sudo make install             2>&1 | tee -a "$THIS_LOG"
 
+popd
 echo "Completed $0 "               | tee -a "$THIS_LOG"
+echo "----------------------------------"

--- a/install_picorv32_riscv32i.sh
+++ b/install_picorv32_riscv32i.sh
@@ -16,40 +16,39 @@ THIS_CLEAN=true
 # we don't want tee to capture exit codes
 set -o pipefail
 
-# ensure we alwaye start from the $WORKSPACE directory
-cd "$WORKSPACE"
 #"***************************************************************************************************"
 # check for valid riscv32 compiler
 #"***************************************************************************************************"
 /opt/riscv32i/bin/riscv32-unknown-elf-gcc --version > /dev/null
 $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
 
-
 # TODO if already installed, prompt user
 
+pushd .
+cd "$WORKSPACE"
 
 echo "***************************************************************************************************"
 echo "  picorv32. Saving log to $THIS_LOG"
 echo "***************************************************************************************************"
 if [ ! -d "$WORKSPACE"/picorv32 ]; then
   git clone --recursive https://github.com/cliffordwolf/picorv32.git 2>&1 | tee -a "$THIS_LOG"
-  $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
-  cd picorv32
+  $SAVED_CURRENT_PATH/check_for_error.sh                               $?          "$THIS_LOG"
+  cd "$WORKSPACE"/picorv32
 else
-  cd picorv32
+  cd "$WORKSPACE"/picorv32
   git fetch                                                          2>&1 | tee -a "$THIS_LOG"
   git pull                                                           2>&1 | tee -a "$THIS_LOG"
-  $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+  $SAVED_CURRENT_PATH/check_for_error.sh                               $?          "$THIS_LOG"
 fi
 
-# we are still in ~/workspace/picorv32
+# we are still in "$WORKSPACE"/picorv32
 # download tools. We can run this multiple times. the tools won't be blindly re-downloaded
 make download-tools
-$SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+$SAVED_CURRENT_PATH/check_for_error.sh                                 $?          "$THIS_LOG"
 
 # install *all four* riscv flavor toolchains:
 # make -j$(nproc) build-tools
 
-cd $SAVED_CURRENT_PATH
-
-echo "Completed $0 "                                                  | tee -a "$THIS_LOG"
+popd
+echo "Completed $0 "                                                      | tee -a "$THIS_LOG"
+echo "----------------------------------"

--- a/install_prjtrellis.sh
+++ b/install_prjtrellis.sh
@@ -16,24 +16,27 @@ THIS_CLEAN=true
 # we don't want tee to capture exit codes
 set -o pipefail
 
-# ensure we alwaye start from the $WORKSPACE directory
-cd "$WORKSPACE"
 #"***************************************************************************************************"
 # Install prjtrellis
 #"***************************************************************************************************"
-sudo apt-get install python3-dev clang cmake                     2>&1 | tee -a "$THIS_LOG"
 
+if [ "$APTGET" == 1 ]; then
+  sudo apt-get install python3-dev clang cmake                   2>&1 | tee -a "$THIS_LOG"
+fi
 
 echo "***************************************************************************************************"
 echo " prjtrellis (required for nextpnr-ecp5). Saving log to $THIS_LOG"
 echo "***************************************************************************************************"
 
+pushd .
+cd $WORKSPACE
+
 # Call the common github checkout:
 
 $SAVED_CURRENT_PATH/fetch_github.sh https://github.com/YosysHQ/prjtrellis prjtrellis $THIS_CHECKOUT  2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+$SAVED_CURRENT_PATH/check_for_error.sh                                     $? "$THIS_LOG"
 
-cd prjtrellis
+cd "$WORKSPACE"/prjtrellis
 
 source environment.sh
 
@@ -46,27 +49,26 @@ if [ "$THIS_CLEAN" == "true" ]; then
   if [ ! -f "Makefile" ]; then
     echo "$0: File 'Makefile' not found. Not cleaning... (probably a fresh git clone)"
   else
-    echo ""                                                          2>&1 | tee -a "$THIS_LOG"
-    echo "make clean"                                                2>&1 | tee -a "$THIS_LOG"
-    make clean                                                     2>&1 | tee -a "$THIS_LOG"
-    $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+    echo ""                                                      2>&1 | tee -a "$THIS_LOG"
+    echo "make clean"                                            2>&1 | tee -a "$THIS_LOG"
+    make clean                                                   2>&1 | tee -a "$THIS_LOG"
+    $SAVED_CURRENT_PATH/check_for_error.sh                                  $? "$THIS_LOG"
   fi
 fi
 
 cmake -DCMAKE_INSTALL_PREFIX=/usr .                              2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+$SAVED_CURRENT_PATH/check_for_error.sh                                      $? "$THIS_LOG"
 
 # see https://stackoverflow.com/questions/9383014/cant-import-my-own-modules-in-python
 # now set above
 # export PYTHONPATH="~/workspace/prjtrellis/database"
 
-make                                                             2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+make -j$(nproc)                                                  2>&1 | tee -a "$THIS_LOG"
+$SAVED_CURRENT_PATH/check_for_error.sh                                      $? "$THIS_LOG"
 
 sudo make install                                                2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+$SAVED_CURRENT_PATH/check_for_error.sh                                      $? "$THIS_LOG"
 
-
-cd $SAVED_CURRENT_PATH
-
+popd
 echo "Completed $0 "                                                  | tee -a "$THIS_LOG"
+echo "----------------------------------"

--- a/install_riscv-gnu-toolchain-rv32i.sh
+++ b/install_riscv-gnu-toolchain-rv32i.sh
@@ -11,33 +11,33 @@
 # we don't want tee to capture exit codes
 set -o pipefail
 
-# ensure we alwaye start from the $WORKSPACE directory
-cd "$WORKSPACE"
 #"***************************************************************************************************"
 # Install riscv-gnu-toolchain-rv32i
 #"***************************************************************************************************"
 THIS_LOG=$LOG_DIRECTORY"/"$THIS_FILE_NAME"_riscv-gnu-toolchain-rv32i_"$LOG_SUFFIX".log"
 
-# Ubuntu packages needed:
-sudo apt-get install autoconf automake autotools-dev curl libmpc-dev \
-        libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo \
-    gperf libtool patchutils bc zlib1g-dev git libexpat1-dev  --assume-yes          2>&1 | tee -a "$THIS_LOG"
+if [ "$APTGET" == 1 ]; then
+  # Needed Ubuntu packages:
+  sudo apt-get install autoconf automake autotools-dev curl libmpc-dev \
+          libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo \
+          gperf libtool patchutils bc zlib1g-dev git libexpat1-dev  --assume-yes    2>&1 | tee -a "$THIS_LOG"
+fi
 
 sudo mkdir -p /opt/riscv32i
 sudo chown $USER /opt/riscv32i
 
-# setup the path, even though there may be nothing in it yet
-cd ulx3s-toolchain
+# # setup the path, even though there may be nothing in it yet
+# cd ulx3s-toolchain
 . ./set_riscv_path.sh
 
-# note we called init.sh when setting the path, so we are back in the $WORKSPACE directory now
+pushd .
+cd "$WORKSPACE"
 
 echo "***************************************************************************************************"
 echo " riscv-gnu-toolchain-rv32i. Saving log to $THIS_LOG"
 echo "***************************************************************************************************"
 
 # users sitting behind a firewall may need these:
-
 git config --global url.https://github.com/.insteadOf                  git://github.com/
 git config --global url.https://git.qemu.org/git/.insteadOf            git://git.qemu-project.org/
 git config --global url.https://anongit.freedesktop.org/git/.insteadOf git://anongit.freedesktop.org/
@@ -45,38 +45,38 @@ git config --global url.https://github.com/riscv.insteadOf             git://git
 
 if [ ! -d "$WORKSPACE"/riscv-gnu-toolchain-rv32i ]; then
   git clone https://github.com/riscv/riscv-gnu-toolchain riscv-gnu-toolchain-rv32i  2>&1 | tee -a "$THIS_LOG"
-  $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+  $SAVED_CURRENT_PATH/check_for_error.sh                                              $?          "$THIS_LOG"
 
-  cd riscv-gnu-toolchain-rv32i
+  cd "$WORKSPACE"/riscv-gnu-toolchain-rv32i
   git checkout 411d134
 
   echo "This next step takes a long time. Be patient:"
   git submodule update --init --recursive
-  $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+  $SAVED_CURRENT_PATH/check_for_error.sh                                              $?          "$THIS_LOG"
 else
-   cd riscv-gnu-toolchain-rv32i
-   git fetch                                                                         2>&1 | tee -a "$THIS_LOG"
+   cd "$WORKSPACE"/riscv-gnu-toolchain-rv32i
+   git fetch                                                                        2>&1 | tee -a "$THIS_LOG"
 
    # we are in a detached head at 411d134 so cannot pull
    # git pull                                                                        2>&1 | tee -a "$THIS_LOG"
    # $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
    # git checkout 411d134
 
-   git submodule update --recursive                                                  2>&1 | tee -a "$THIS_LOG"
+   git submodule update --recursive                                                 2>&1 | tee -a "$THIS_LOG"
 fi
 
 # after we have new (or fresh) files, build
-mkdir -p build;                                                                     2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+mkdir -p "$WORKSPACE"/riscv-gnu-toolchain-rv32i/build;                              2>&1 | tee -a "$THIS_LOG"
+$SAVED_CURRENT_PATH/check_for_error.sh                                                $?          "$THIS_LOG"
 
-cd build
+cd "$WORKSPACE"/riscv-gnu-toolchain-rv32i/build
 
 ../configure --with-arch=rv32i --prefix=/opt/riscv32i                               2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+$SAVED_CURRENT_PATH/check_for_error.sh                                                $?          "$THIS_LOG"
 
 make -j$(nproc)                                                                     2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+$SAVED_CURRENT_PATH/check_for_error.sh                                                $?          "$THIS_LOG"
 
-echo "Completed $0 "                                                  | tee -a "$THIS_LOG"
-
-
+popd
+echo "Completed $0 "                                                                     | tee -a "$THIS_LOG"
+echo "----------------------------------"

--- a/install_rxrbln-picorv32.sh
+++ b/install_rxrbln-picorv32.sh
@@ -11,8 +11,6 @@
 # we don't want tee to capture exit codes
 set -o pipefail
 
-# ensure we alwaye start from the $WORKSPACE directory
-cd "$WORKSPACE"
 #"***************************************************************************************************"
 # Install the picorv32 from rxrbln that has some interesting ULX3S work
 #"***************************************************************************************************"
@@ -20,22 +18,24 @@ cd "$WORKSPACE"
 echo "***************************************************************************************************"
 echo "rxrbln's fork of picorv32 for the ULX3S. Saving log to $THIS_LOG"
 echo "***************************************************************************************************"
+
+pushd .
+cd "$WORKSPACE"
+
 if [ ! -d "$WORKSPACE"/rxrbln-picorv32 ]; then
   git clone --recursive https://github.com/rxrbln/picorv32 rxrbln-picorv32  2>&1 | tee -a "$THIS_LOG"
-  $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+  $SAVED_CURRENT_PATH/check_for_error.sh                                      $?          "$THIS_LOG"
   cd rxrbln-picorv32
 else
   cd rxrbln-picorv32
   git fetch                                                       2>&1 | tee -a "$THIS_LOG"
   git pull                                                        2>&1 | tee -a "$THIS_LOG"
-  $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+  $SAVED_CURRENT_PATH/check_for_error.sh                            $?          "$THIS_LOG"
 fi
 
-make                                                              2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+make -j$(nproc)                                                   2>&1 | tee -a "$THIS_LOG"
+$SAVED_CURRENT_PATH/check_for_error.sh                              $?          "$THIS_LOG"
 
-cd $SAVED_CURRENT_PATH
-
+popd
 echo "Completed $0 "                                                   | tee -a "$THIS_LOG"
-
-
+echo "----------------------------------"

--- a/install_set_permissions.sh
+++ b/install_set_permissions.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 echo "Setting permissions for all scripts in $(pwd)"
 
-
 for file in ./*.sh
 do
   echo "chmod +x $file"

--- a/install_system.sh
+++ b/install_system.sh
@@ -11,142 +11,128 @@
 # we don't want tee to capture exit codes
 set -o pipefail
 
-# ensure we alwaye start from the $WORKSPACE directory
-cd "$WORKSPACE"
-#"***************************************************************************************************"
-# Install all system dependencies and updates
-#"***************************************************************************************************"
-
-echo "***************************************************************************************************"
-echo "update/upgrade current system. Saving log to $THIS_LOG"
-echo "***************************************************************************************************"
-sudo apt-get update --assume-yes        2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh    $?          "$THIS_LOG"
-
-sudo apt-get upgrade --assume-yes       2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh    $?          "$THIS_LOG"
-
-echo "***************************************************************************************************"
-echo "git install and config. Saving log to $THIS_LOG"
-echo "***************************************************************************************************"
-# These git .insteadOf options may not be needed if your firewall does not blocks the git ports, 
-# but we set anyhow. 
-#
-# it is unlikely to cause harm for these repositories, unless for some reason your firewall is blocking HTTPS
-sudo apt-get install git --assume-yes   2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh    $?          "$THIS_LOG"
-
-# git config --global url.https://git.qemu.org/git/.insteadOf git://git.qemu-project.org/
-# git config --global url.https://anongit.freedesktop.org/git/.insteadOf git://anongit.freedesktop.org/
-
-# git config --global url.https://github.com/riscv.insteadOf git://github.com/riscv
-
-# also consider somerthing like this for everything on GitHub:
-# git config --global url.https://github.com/.insteadOf git://github.com/
-#
-# and to clear:
-# git config --global --unset url.https://github.com/.insteadOf
-
-echo "***************************************************************************************************"
-echo " install x11 dependencies (only needed for WSL?)"
-echo "***************************************************************************************************"
-sudo apt install dbus-x11 --assume-yes
-$SAVED_CURRENT_PATH/check_for_error.sh    $?           "$THIS_LOG"
-
-cd "$WORKSPACE"
-echo "***************************************************************************************************"
-echo "install icestorm dependencies. Saving log to $THIS_LOG"
-echo "***************************************************************************************************"
-# this next install needs a bit of disk space:
-#   0 upgraded, 205 newly installed, 0 to remove and 3 not upgraded.
-#   Need to get 130 MB of archives.
-#   After this operation, 652 MB of additional disk space will be used.
-#
-sudo apt-get install build-essential clang bison flex libreadline-dev \
-					 gawk tcl-dev libffi-dev git mercurial graphviz   \
-					 xdot pkg-config libftdi-dev --assume-yes 2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh                          $?          "$THIS_LOG"
-
-
-echo "***************************************************************************************************"
-echo "install Python and dependencies. Saving log to $THIS_LOG"
-echo "***************************************************************************************************"
-sudo apt-get install python python3  --assume-yes  2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh               $?          "$THIS_LOG"
-
-sudo apt-get install python3-pip --assume-yes      2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh               $?          "$THIS_LOG"
-
-pip3 install database                              2>&1 | tee -a "$THIS_LOG"
-
-echo "***************************************************************************************************"
-echo "install apio. Saving log to $THIS_LOG"
-echo "***************************************************************************************************"
-pip3 install -U apio                 2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh $?          "$THIS_LOG"
-
-echo "***************************************************************************************************"
-echo "install nextpnr dependencies. Saving log to $THIS_LOG"
-echo "***************************************************************************************************"
-# this next line is about another half gig of files!
-#   0 upgraded, 249 newly installed, 0 to remove and 3 not upgraded.
-#   Need to get 132 MB of archives.
-#   After this operation, 623 MB of additional disk space will be used.
-#
-sudo apt-get install libboost-all-dev python3-dev qt5-default clang-format libeigen3-dev --assume-yes 2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh    $?          "$THIS_LOG"
-
-sudo apt-get install cmake --assume-yes 2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh    $?          "$THIS_LOG"
-
-echo "***************************************************************************************************"
-echo "install RISCV system dependencies. Saving log to $THIS_LOG"
-echo "***************************************************************************************************"
-sudo apt-get install make        --assume-yes      2>&1 | tee -a "$THIS_LOG"
-sudo apt-get install make-guile  --assume-yes      2>&1 | tee -a "$THIS_LOG"
-sudo apt-get install libgmp3-dev --assume-yes      2>&1 | tee -a "$THIS_LOG"
-sudo apt-get install libmpfr-dev --assume-yes      2>&1 | tee -a "$THIS_LOG"
-sudo apt-get install libmpc-dev  --assume-yes      2>&1 | tee -a "$THIS_LOG"
-
-sudo apt-get install autoconf automake autotools-dev curl libmpc-dev \
-        libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo \
-    gperf libtool patchutils bc zlib1g-dev git libexpat1-dev --assume-yes  2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
-
-echo "***************************************************************************************************"
-echo "install iverilog. Saving log to $THIS_LOG"
-echo "***************************************************************************************************"
-sudo apt-get install iverilog --assume-yes  2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh        $?          "$THIS_LOG"
-
-
-
-echo "***************************************************************************************************"
-echo "install verilator. Saving log to $THIS_LOG"
-echo "***************************************************************************************************"
-# The following NEW packages will be installed:
-#  verilator
-# 0 upgraded, 1 newly installed, 0 to remove and 1 not upgraded.
-# Need to get 2878 kB of archives.
-# After this operation, 13.1 MB of additional disk space will be used.
-sudo apt-get install verilator  --assume-yes    2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh $?          "$THIS_LOG"
-
-if grep -q Microsoft /proc/version; then
+if [ "$APTGET" == 1 ]; then
+  #"***************************************************************************************************"
+  # Install all system dependencies and updates
+  #"***************************************************************************************************"
   echo "***************************************************************************************************"
-  echo "WSL detected; Install x86_64-w64-mingw32-gcc; Saving log to $THIS_LOG"
+  echo "update/upgrade current system. Saving log to $THIS_LOG"
   echo "***************************************************************************************************"
-  sudo apt-get install mingw-w64   --assume-yes    2>&1 | tee -a "$THIS_LOG"
-  $SAVED_CURRENT_PATH/check_for_error.sh             $?          "$THIS_LOG"
+  sudo apt-get update --assume-yes        2>&1 | tee -a "$THIS_LOG"
+  ./check_for_error.sh                      $?          "$THIS_LOG"
+
+  sudo apt-get upgrade --assume-yes       2>&1 | tee -a "$THIS_LOG"
+  ./check_for_error.sh                      $?          "$THIS_LOG"
+
+  echo "***************************************************************************************************"
+  echo "git install and config. Saving log to $THIS_LOG"
+  echo "***************************************************************************************************"
+  # These git .insteadOf options may not be needed if your firewall does not blocks the git ports, 
+  # but we set anyhow. 
+  #
+  # it is unlikely to cause harm for these repositories, unless for some reason your firewall is blocking HTTPS
+  sudo apt-get install git --assume-yes   2>&1 | tee -a "$THIS_LOG"
+  ./check_for_error.sh                      $?          "$THIS_LOG"
+
+  echo "***************************************************************************************************"
+  echo " install x11 dependencies (only needed for WSL?)"
+  echo "***************************************************************************************************"
+  sudo apt install dbus-x11 --assume-yes
+  ./check_for_error.sh                      $?           "$THIS_LOG"
+
+  echo "***************************************************************************************************"
+  echo "install icestorm dependencies. Saving log to $THIS_LOG"
+  echo "***************************************************************************************************"
+  # this next install needs a bit of disk space:
+  #   0 upgraded, 205 newly installed, 0 to remove and 3 not upgraded.
+  #   Need to get 130 MB of archives.
+  #   After this operation, 652 MB of additional disk space will be used.
+  #
+  sudo apt-get install build-essential clang bison flex libreadline-dev \
+            gawk tcl-dev libffi-dev git mercurial graphviz   \
+            xdot pkg-config libftdi-dev --assume-yes 2>&1 | tee -a "$THIS_LOG"
+  ./check_for_error.sh                                 $?          "$THIS_LOG"
+
+  echo "***************************************************************************************************"
+  echo "install Python and dependencies. Saving log to $THIS_LOG"
+  echo "***************************************************************************************************"
+  sudo apt-get install python python3  --assume-yes  2>&1 | tee -a "$THIS_LOG"
+  ./check_for_error.sh                                 $?          "$THIS_LOG"
+
+  sudo apt-get install python3-pip --assume-yes      2>&1 | tee -a "$THIS_LOG"
+  ./check_for_error.sh                                 $?          "$THIS_LOG"
+
+  pip3 install databases                             2>&1 | tee -a "$THIS_LOG"
+
+  echo "***************************************************************************************************"
+  echo "install apio. Saving log to $THIS_LOG"
+  echo "***************************************************************************************************"
+  pip3 install -U apio                 2>&1 | tee -a "$THIS_LOG"
+  ./check_for_error.sh                   $?          "$THIS_LOG"
+
+  echo "***************************************************************************************************"
+  echo "install nextpnr dependencies. Saving log to $THIS_LOG"
+  echo "***************************************************************************************************"
+  # this next line is about another half gig of files!
+  #   0 upgraded, 249 newly installed, 0 to remove and 3 not upgraded.
+  #   Need to get 132 MB of archives.
+  #   After this operation, 623 MB of additional disk space will be used.
+  #
+  sudo apt-get install libboost-all-dev python3-dev qt5-default \
+            clang-format libeigen3-dev --assume-yes 2>&1 | tee -a "$THIS_LOG"
+  ./check_for_error.sh                      $?                    "$THIS_LOG"
+
+  sudo apt-get install cmake --assume-yes 2>&1 | tee -a           "$THIS_LOG"
+  ./check_for_error.sh                      $?                    "$THIS_LOG"
+
+  echo "***************************************************************************************************"
+  echo "install RISCV system dependencies. Saving log to $THIS_LOG"
+  echo "***************************************************************************************************"
+  sudo apt-get install make        --assume-yes      2>&1 | tee -a "$THIS_LOG"
+  sudo apt-get install make-guile  --assume-yes      2>&1 | tee -a "$THIS_LOG"
+  sudo apt-get install libgmp3-dev --assume-yes      2>&1 | tee -a "$THIS_LOG"
+  sudo apt-get install libmpfr-dev --assume-yes      2>&1 | tee -a "$THIS_LOG"
+  sudo apt-get install libmpc-dev  --assume-yes      2>&1 | tee -a "$THIS_LOG"
+
+  sudo apt-get install autoconf automake autotools-dev curl libmpc-dev \
+            libmpfr-dev libgmp-dev gawk build-essential bison flex texinfo \
+            gperf libtool patchutils bc zlib1g-dev git libexpat1-dev --assume-yes  2>&1 | tee -a "$THIS_LOG"
+  ./check_for_error.sh                   $?                                                      "$THIS_LOG"
+
+  echo "***************************************************************************************************"
+  echo "install iverilog. Saving log to $THIS_LOG"
+  echo "***************************************************************************************************"
+  sudo apt-get install iverilog --assume-yes  2>&1 | tee -a "$THIS_LOG"
+  ./check_for_error.sh                          $?          "$THIS_LOG"
+
+  echo "***************************************************************************************************"
+  echo "install verilator. Saving log to $THIS_LOG"
+  echo "***************************************************************************************************"
+  # The following NEW packages will be installed:
+  #  verilator
+  # 0 upgraded, 1 newly installed, 0 to remove and 1 not upgraded.
+  # Need to get 2878 kB of archives.
+  # After this operation, 13.1 MB of additional disk space will be used.
+  sudo apt-get install verilator  --assume-yes    2>&1 | tee -a "$THIS_LOG"
+  ./check_for_error.sh                              $?          "$THIS_LOG"
+
+  if grep -q Microsoft /proc/version; then
+    echo "***************************************************************************************************"
+    echo "WSL detected; Install x86_64-w64-mingw32-gcc; Saving log to $THIS_LOG"
+    echo "***************************************************************************************************"
+    sudo apt-get install mingw-w64   --assume-yes    2>&1 | tee -a "$THIS_LOG"
+    ./check_for_error.sh                               $?          "$THIS_LOG"
+  fi
+
+  echo "***************************************************************************************************"
+  echo "update/upgrade current system again. Saving log to $THIS_LOG"
+  echo "***************************************************************************************************"
+  sudo apt-get update --assume-yes        2>&1 | tee -a "$THIS_LOG"
+  ./check_for_error.sh                      $?          "$THIS_LOG"
+
+  sudo apt-get upgrade --assume-yes       2>&1 | tee -a "$THIS_LOG"
+  ./check_for_error.sh                      $?          "$THIS_LOG"
 fi
 
-echo "***************************************************************************************************"
-echo "update/upgrade current system again. Saving log to $THIS_LOG"
-echo "***************************************************************************************************"
-sudo apt-get update --assume-yes        2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh    $?          "$THIS_LOG"
-
-sudo apt-get upgrade --assume-yes       2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh    $?          "$THIS_LOG"
-
 echo "Completed $0 " | tee -a "$THIS_LOG"
+echo "----------------------------------"

--- a/install_udev_rules.sh
+++ b/install_udev_rules.sh
@@ -12,13 +12,9 @@
 # we don't want tee to capture exit codes
 set -o pipefail
 
-# ensure we alwaye start from the $WORKSPACE directory
-cd "$WORKSPACE"
 #"***************************************************************************************************"
 # Install udev rules
 #"***************************************************************************************************"
-cd ulx3s-toolchain
-
 # see https://github.com/emard/ulx3s-bin
 
 if [ -f "/etc/udev/rules.d/80-fpga-ulx3s.rules" ]; then
@@ -26,5 +22,9 @@ if [ -f "/etc/udev/rules.d/80-fpga-ulx3s.rules" ]; then
 else
   echo "Copy /etc/udev/rules.d/80-fpga-ulx3s.rules"                       2>&1 | tee -a "$THIS_LOG"
   sudo cp 80-fpga-ulx3s.rules /etc/udev/rules.d/80-fpga-ulx3s.rules       2>&1 | tee -a "$THIS_LOG"
-  $SAVED_CURRENT_PATH/check_for_error.sh   $?          "$THIS_LOG"
+  $SAVED_CURRENT_PATH/check_for_error.sh   $?                                           "$THIS_LOG"
 fi
+
+echo "Completed $0 " | tee -a "$THIS_LOG"
+echo "----------------------------------"
+

--- a/install_ujprog.sh
+++ b/install_ujprog.sh
@@ -24,20 +24,24 @@ echo " ujprog. Saving log to $THIS_LOG"
 echo "***************************************************************************************************"
 # see https://github.com/f32c/tools/tree/master/ujprog
 # NOTE: Although this successfully compiles, it does not seem to work in WSL (no USB device support, use EXE instead)
+
+pushd .
+cd "$WORKSPACE"
+
 if [ ! -d "$WORKSPACE"/f32c_tools ]; then
   git clone https://github.com/f32c/tools.git f32c_tools         2>&1 | tee -a "$THIS_LOG"
-  $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
-  cd f32c_tools/ujprog
+  $SAVED_CURRENT_PATH/check_for_error.sh                           $?          "$THIS_LOG"
+  cd "$WORKSPACE"/f32c_tools/ujprog
 else
-  cd f32c_tools
+  cd "$WORKSPACE"/f32c_tools
   git fetch                                                      2>&1 | tee -a "$THIS_LOG"
   git pull                                                       2>&1 | tee -a "$THIS_LOG"
-  $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+  $SAVED_CURRENT_PATH/check_for_error.sh                           $?          "$THIS_LOG"
 
-  cd ujprog
+  cd "$WORKSPACE"/ujprog
 
   # make clean                                                     2>&1 | tee -a "$THIS_LOG"
-  $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+  $SAVED_CURRENT_PATH/check_for_error.sh                           $?          "$THIS_LOG"
 fi
 
 # There's no point to making the linux version of ujprog in WSL, as native USB devices are not supported.
@@ -48,24 +52,24 @@ if grep -q Microsoft /proc/version; then
   echo "***************************************************************************************************"
 
   make -f Makefile.ming32_64                                     2>&1 | tee -a "$THIS_LOG"
-  $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+  $SAVED_CURRENT_PATH/check_for_error.sh                           $?          "$THIS_LOG"
 
   # sudo make -f Makefile.ming32_64 install                        2>&1 | tee -a "$THIS_LOG"
   $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
 else
   make -f Makefile.linux                                         2>&1 | tee -a "$THIS_LOG"
-  $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+  $SAVED_CURRENT_PATH/check_for_error.sh                           $?          "$THIS_LOG"
 
   sudo make -f Makefile.linux install                            2>&1 | tee -a "$THIS_LOG"
-  $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+  $SAVED_CURRENT_PATH/check_for_error.sh                           $?          "$THIS_LOG"
    
   # The default install directory for ujprog is /usr/local/bin/ujprog however the rxrbln Makefile 
   # expects it to be /usr/src/f32c-ujprog/ujprog/ujprog so we'll just create a quick symlink
   sudo mkdir -p /usr/src/f32c-ujprog/ujprog/
   sudo ln -s /usr/local/bin/ujprog /usr/src/f32c-ujprog/ujprog/ujprog
-  $SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+  $SAVED_CURRENT_PATH/check_for_error.sh                           $?          "$THIS_LOG"
 fi
 
-cd $SAVED_CURRENT_PATH
-
+popd
 echo "Completed $0 "                                                  | tee -a "$THIS_LOG"
+echo "----------------------------------"

--- a/install_ulx3s-bin.sh
+++ b/install_ulx3s-bin.sh
@@ -16,8 +16,6 @@ THIS_CLEAN=true
 # we don't want tee to capture exit codes
 set -o pipefail
 
-# ensure we alwaye start from the $WORKSPACE directory
-cd "$WORKSPACE"
 #"***************************************************************************************************"
 # install the repo of pre-compile binaries
 #"***************************************************************************************************"
@@ -29,13 +27,16 @@ echo "**************************************************************************
 
 # Call the common github checkout:
 
-$SAVED_CURRENT_PATH/fetch_github.sh https://github.com/ulx3s/ulx3s-bin.git ulx3s-bin $THIS_CHECKOUT  2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+pushd .
+cd "$WORKSPACE"
 
-cd ulx3s-bin
+$SAVED_CURRENT_PATH/fetch_github.sh https://github.com/ulx3s/ulx3s-bin.git ulx3s-bin $THIS_CHECKOUT  2>&1 | tee -a "$THIS_LOG"
+$SAVED_CURRENT_PATH/check_for_error.sh                                                                 $?          "$THIS_LOG"
+
+cd "$WORKSPACE"/ulx3s-bin
 
 # TODO - any checks here?
 
-cd $SAVED_CURRENT_PATH
-
-echo "Completed $0 "                                                  | tee -a "$THIS_LOG"
+popd
+echo "Completed $0"                                                   | tee -a "$THIS_LOG"
+echo "----------------------------------"

--- a/install_ulx3s-examples.sh
+++ b/install_ulx3s-examples.sh
@@ -16,8 +16,6 @@ THIS_CLEAN=true
 # we don't want tee to capture exit codes
 set -o pipefail
 
-# ensure we alwaye start from the $WORKSPACE directory
-cd "$WORKSPACE"
 #"***************************************************************************************************"
 # fetch the ULX3S examples into the workspace
 #"***************************************************************************************************"
@@ -29,13 +27,16 @@ echo "**************************************************************************
 
 # Call the common github checkout:
 
-$SAVED_CURRENT_PATH/fetch_github.sh https://github.com/ulx3s/ulx3s-examples.git ulx3s-examples $THIS_CHECKOUT  2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+pushd .
+cd "$WORKSPACE"
 
-cd ulx3s-examples
+$SAVED_CURRENT_PATH/fetch_github.sh https://github.com/ulx3s/ulx3s-examples.git ulx3s-examples $THIS_CHECKOUT  2>&1 | tee -a "$THIS_LOG"
+$SAVED_CURRENT_PATH/check_for_error.sh                                                                           $?          "$THIS_LOG"
+
+cd "$WORKSPACE"/ulx3s-examples
 
 # TODO - any checks?
 
-cd $SAVED_CURRENT_PATH
-
+popd
 echo "Completed $0 "                                                  | tee -a "$THIS_LOG"
+echo "----------------------------------"

--- a/install_ulx3s-misc.sh
+++ b/install_ulx3s-misc.sh
@@ -16,8 +16,6 @@ THIS_CLEAN=true
 # we don't want tee to capture exit codes
 set -o pipefail
 
-# ensure we alwaye start from the $WORKSPACE directory
-cd "$WORKSPACE"
 #"***************************************************************************************************"
 # fetch the advanced ULX3S examples into the workspace
 #"***************************************************************************************************"
@@ -28,13 +26,16 @@ echo "**************************************************************************
 
 # Call the common github checkout:
 
-$SAVED_CURRENT_PATH/fetch_github.sh https://github.com/emard/ulx3s-misc ulx3s-misc $THIS_CHECKOUT  2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+pushd .
+cd "$WORKSPACE"
 
-cd ulx3s-misc
+$SAVED_CURRENT_PATH/fetch_github.sh https://github.com/emard/ulx3s-misc ulx3s-misc $THIS_CHECKOUT  2>&1 | tee -a "$THIS_LOG"
+$SAVED_CURRENT_PATH/check_for_error.sh                                                               $?          "$THIS_LOG"
+
+cd "$WORKSPACE"/ulx3s-misc
 
 # TODO any checks?
 
-cd $SAVED_CURRENT_PATH
-
-echo "Completed $0 "                                                  | tee -a "$THIS_LOG"
+popd
+echo "Completed $0 "                                                                                    | tee -a "$THIS_LOG"
+echo "----------------------------------"

--- a/install_ulx3s.sh
+++ b/install_ulx3s.sh
@@ -16,8 +16,6 @@ THIS_CLEAN=true
 # we don't want tee to capture exit codes
 set -o pipefail
 
-# ensure we alwaye start from the $WORKSPACE directory
-cd "$WORKSPACE"
 #"***************************************************************************************************"
 # install emard's repo of all the great ULX3S docs
 #"***************************************************************************************************"
@@ -28,13 +26,16 @@ echo "**************************************************************************
 
 # Call the common github checkout:
 
-$SAVED_CURRENT_PATH/fetch_github.sh https://github.com/emard/ulx3s ulx3s $THIS_CHECKOUT  2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh $? "$THIS_LOG"
+pushd .
+cd "$WORKSPACE"
 
-cd ulx3s
+$SAVED_CURRENT_PATH/fetch_github.sh https://github.com/emard/ulx3s ulx3s $THIS_CHECKOUT  2>&1 | tee -a "$THIS_LOG"
+$SAVED_CURRENT_PATH/check_for_error.sh                                                     $?          "$THIS_LOG"
+
+cd "$WORKSPACE"/ulx3s
 
 # TODO - any checks here?
 
-cd $SAVED_CURRENT_PATH
-
-echo "Completed $0 "                                                  | tee -a "$THIS_LOG"
+popd
+echo "Completed $0 "                                                                          | tee -a "$THIS_LOG"
+echo "----------------------------------"

--- a/install_verilator.sh
+++ b/install_verilator.sh
@@ -16,33 +16,32 @@
 # we don't want tee to capture exit codes
 set -o pipefail
 
-# ensure we alwaye start from the $WORKSPACE directory
-cd "$WORKSPACE"
-#"***************************************************************************************************"
-# install verilator and dependencies
-#"***************************************************************************************************"
-
-echo "***************************************************************************************************"
-echo "install verilator. Saving log to $THIS_LOG"
-echo "***************************************************************************************************"
-# The following NEW packages will be installed:
-#  verilator
-# 0 upgraded, 1 newly installed, 0 to remove and 1 not upgraded.
-# Need to get 2878 kB of archives.
-# After this operation, 13.1 MB of additional disk space will be used.
-sudo apt-get install verilator --assume-yes    2>&1 | tee -a "$THIS_LOG"
-$SAVED_CURRENT_PATH/check_for_error.sh           $? "$THIS_LOG"
-
-if grep -q Microsoft /proc/version; then
+if [ "$APTGET" == 1 ]; then
+  #"***************************************************************************************************"
+  # install verilator and dependencies
+  #"***************************************************************************************************"
   echo "***************************************************************************************************"
-  echo "WSL detected; Install x86_64-w64-mingw32-gcc; Saving log to $THIS_LOG"
+  echo "install verilator. Saving log to $THIS_LOG"
   echo "***************************************************************************************************"
-  sudo apt-get install mingw-w64 --assume-yes  2>&1 | tee -a "$THIS_LOG"
-  $SAVED_CURRENT_PATH/check_for_error.sh         $?          "$THIS_LOG"
+  # The following NEW packages will be installed:
+  #  verilator
+  # 0 upgraded, 1 newly installed, 0 to remove and 1 not upgraded.
+  # Need to get 2878 kB of archives.
+  # After this operation, 13.1 MB of additional disk space will be used.
+  sudo apt-get install verilator --assume-yes    2>&1 | tee -a "$THIS_LOG"
+  $SAVED_CURRENT_PATH/check_for_error.sh           $? "$THIS_LOG"
+
+  if grep -q Microsoft /proc/version; then
+    echo "***************************************************************************************************"
+    echo "WSL detected; Install x86_64-w64-mingw32-gcc; Saving log to $THIS_LOG"
+    echo "***************************************************************************************************"
+    sudo apt-get install mingw-w64 --assume-yes  2>&1 | tee -a "$THIS_LOG"
+    $SAVED_CURRENT_PATH/check_for_error.sh         $?          "$THIS_LOG"
+  fi
 fi
 
 echo ""                                             | tee -a "$THIS_LOG"
 verilator --version                                 | tee -a "$THIS_LOG"
 echo ""                                             | tee -a "$THIS_LOG"
-
 echo "Completed $0 "                                | tee -a "$THIS_LOG"
+echo "----------------------------------"

--- a/set_riscv_path.sh
+++ b/set_riscv_path.sh
@@ -24,5 +24,5 @@ if [ "$(echo $PATH | grep  $THIS_RISCV_PATH)" == "" ]; then
   export PATH=$PATH:$THIS_RISCV_PATH
   echo "Updated current path: $PATH"
 else
-  echo "Path not updated. PATH=$PATH"
+  echo "Path already correct. PATH=$PATH"
 fi

--- a/soft_cpu.sh
+++ b/soft_cpu.sh
@@ -23,7 +23,7 @@ set -o pipefail
 #"***************************************************************************************************"
 
 # make the soft CPU
-cd $WORKSPACE/litex-boards/litex_boards/targets
+cd "$WORKSPACE"/litex-boards/litex_boards/targets
 
 # $THIS_ULX3S_DEVICE contains a value such as LFE5U-85F
 ./ulx3s.py --device $THIS_ULX3S_DEVICE --cpu-type picorv32
@@ -38,7 +38,7 @@ echo "ULX3S BIOS:"
 ls $WORKSPACE/litex-boards/litex_boards/targets/soc_basesoc_ulx3s/software/bios -al
 
 # put the soft CPU on the ULX3S
-cd $WORKSPACE/litex-boards/litex_boards/targets/soc_basesoc_ulx3s/gateware
+cd "$WORKSPACE"/litex-boards/litex_boards/targets/soc_basesoc_ulx3s/gateware
 $WORKSPACE/ulx3s-examples/bin/ujprog.exe top.bit
 
 # helpful notes from @GregDavill: (see https://twitter.com/gojimmypi/status/1241485830356496384?s=20)
@@ -55,7 +55,7 @@ $WORKSPACE/ulx3s-examples/bin/ujprog.exe top.bit
 # The bios exists to initialise things like SDRAM, which you can see it doing here. It then tries 
 # to load a USER program from SD/FLASH/Serial/Ethernet.
 
-cd $WORKSPACE/litex-boards/litex_boards/targets/soc_basesoc_ulx3s/software/bios
+cd "$WORKSPACE"/litex-boards/litex_boards/targets/soc_basesoc_ulx3s/software/bios
 litex_term --serial-boot --kernel bios.bin /dev/ttyS15
 
 # press enter to confirm LiteX prompt, then type "reboot" (without quotes, then enter )


### PR DESCRIPTION
…y Linux distro plus some cleanup.

Hi,

I received my ulx3s boards last week and I wanted to install the toolchains. Only to discover that the install scripts can only work on Ubuntu (and similar distro's). And I'm a Manjaro user (Arch based).

I don't really like the idea of creating a Ubuntu VM just to get to the toolchains (which can work on any Linux distro) so I set of to adapt the install scripts so that the ulx3s tools can be installed on any distro (and probably macOS as well).

Attached you can find a patch file instead of the pull request I tried. It's a bit big. This is an overview what I attempted to achieve with my changes:
* The main bottleneck is the usage of "sudo apt-get install ...". To work around this, I introduced a new argument that can be added on the command line:
    install.sh barebones aptget
  When aptget is specified, the install scripts will attempt to install the required packages as the scripts used to do. Without that argument, the scripts will not install any packages and the script should now run on any Linux Distro.
  However, I feel that installing the packages should not belong in install scripts (this repo is the first time I saw this happening). Maybe it's better to specify in the readme.md file which packages are needed. Be aware that packages can have a different name as well between distro's. E.g. build-essential is base-devel for Arch Linux.
* I renamed the default workspace name to "ULX3S_workspace". It makes it immediately clear what the purpose is and it might avoid clashes with other tools (e.g. Eclipse which also likes to use the name "workspace").
* For some reason, the ulx3s-toolchain repo is cloned inside the workspace and when the install scripts are run, the install scripts are suddenly picked up from the repo inside the workspace (not the one you originally started from). This can cause a lot of confusion and made it hard to debug. The ulx3s-toolchain repo is still cloned in the workspace but is not used anymore. The install scripts now always return back to the directory you started from (you'll see a lot the usage of the "pushd ."/"popd" command pair).
* All make commands are now in the form "make -j$(nproc)". This can speed up the build quite a lot (I have a 12 core/24 thread PC and I do a clean build in about an hour now).
* The esp repo is now cloned inside the workspace directory (it used to end up in the home directory which was probably not the intention).
* This is probably wrong in install_system.sh (it generates an error for me):
    pip3 install database
  and has to be:
    pip3 install databases
* Error checking could still be improved. When I compile the openocd-esp32 repo, I get compile errors (actually these are warnings but they've been converted to errors because the -Werror flag is set during compilation). I see these warnings/errors when using GCC 10.2.0 (one of the disadvantages of a rolling distribution like Manjaro is that you always have the most recent tools and thus can bump in this kind of issues more often). 
* Various cleanups/beatification.
* Things I might have already forgot :-(

I hope you find this useful. It's by no means complete but maybe it can help to streamline the install scripts into a better shape and usable on all Linux Distros without the need of a VM.